### PR TITLE
puppet/python: Allow 5.x and 6.x

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -232,33 +232,7 @@ simple tests against it after applying the module. You can run this
 with:
 
 ```sh
-bundle exec rake beaker
-```
-
-This will run the tests on the module's default nodeset. You can override the
-nodeset used, e.g.,
-
-```sh
-BEAKER_set=centos-7-x64 bundle exec rake beaker
-```
-
-There are default rake tasks for the various acceptance test modules, e.g.,
-
-```sh
-bundle exec rake beaker:centos-7-x64
-bundle exec rake beaker:ssh:centos-7-x64
-```
-
-If you don't want to have to recreate the virtual machine every time you can
-use `BEAKER_destroy=no` and `BEAKER_provision=no`. On the first run you will at
-least need `BEAKER_provision` set to yes (the default). The Vagrantfile for the
-created virtual machines will be in `.vagrant/beaker_vagrant_files`.
-
-Beaker also supports docker containers. We also use that in our automated CI
-pipeline at [travis-ci](http://travis-ci.org). To use that instead of Vagrant:
-
-```sh
-PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=debian10-64{hypervisor=docker} BEAKER_destroy=yes bundle exec rake beaker
+BEAKER_setfile=debian10-x64 bundle exec rake beaker
 ```
 
 You can replace the string `debian10` with any common operating system.
@@ -272,11 +246,7 @@ The following strings are known to work:
 * centos7
 * centos8
 
-The easiest way to debug in a docker container is to open a shell:
-
-```sh
-docker exec -it -u root ${container_id_or_name} bash
-```
+For more information and tips & tricks, see [voxpupuli-acceptance's documentation](https://github.com/voxpupuli/voxpupuli-acceptance#running-tests).
 
 The source of this file is in our [modulesync_config](https://github.com/voxpupuli/modulesync_config/blob/master/moduleroot/.github/CONTRIBUTING.md.erb)
 repository.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,13 @@ jobs:
   setup_matrix:
     name: 'Setup Test Matrix'
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     outputs:
       beaker_setfiles: ${{ steps.get-outputs.outputs.beaker_setfiles }}
       puppet_major_versions: ${{ steps.get-outputs.outputs.puppet_major_versions }}
       puppet_unit_test_matrix: ${{ steps.get-outputs.outputs.puppet_unit_test_matrix }}
     env:
-      BUNDLE_WITHOUT: development:test:release
+      BUNDLE_WITHOUT: development:release
     steps:
       - uses: actions/checkout@v2
       - name: Setup ruby
@@ -21,6 +22,8 @@ jobs:
           bundler-cache: true
       - name: Run rake validate
         run: bundle exec rake validate
+      - name: Run rake rubocop
+        run: bundle exec rake rubocop
       - name: Setup Test Matrix
         id: get-outputs
         run: bundle exec metadata2gha --use-fqdn --pidfile-workaround false
@@ -28,6 +31,7 @@ jobs:
   unit:
     needs: setup_matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
@@ -58,10 +62,6 @@ jobs:
         puppet: ${{fromJson(needs.setup_matrix.outputs.puppet_major_versions)}}
     name: ${{ matrix.puppet.name }} - ${{ matrix.setfile.name }}
     steps:
-      - name: Enable IPv6 on docker
-        run: |
-          echo '{"ipv6":true,"fixed-cidr-v6":"2001:db8:1::/64"}' | sudo tee /etc/docker/daemon.json
-          sudo service docker restart
       - uses: actions/checkout@v2
       - name: Setup ruby
         uses: ruby/setup-ruby@v1

--- a/.msync.yml
+++ b/.msync.yml
@@ -1,2 +1,2 @@
 ---
-modulesync_config_version: '4.0.0'
+modulesync_config_version: '4.1.0'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.3
+FROM ruby:2.7
 
 WORKDIR /opt/puppet
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,17 +17,17 @@ group :system_tests do
 end
 
 group :release do
-  gem 'github_changelog_generator',  :require => false, :git => 'https://github.com/voxpupuli/github-changelog-generator', :branch => 'voxpupuli_essential_fixes'
-  gem 'puppet-blacksmith',           :require => false
-  gem 'voxpupuli-release',           :require => false
-  gem 'puppet-strings', '>= 2.2',    :require => false
+  gem 'github_changelog_generator', '>= 1.16.1',  :require => false
+  gem 'puppet-blacksmith',                        :require => false
+  gem 'voxpupuli-release',                        :require => false
+  gem 'puppet-strings', '>= 2.2',                 :require => false
 end
 
 gem 'puppetlabs_spec_helper', '~> 2.0', :require => false
 gem 'rake', :require => false
 gem 'facter', ENV['FACTER_GEM_VERSION'], :require => false, :groups => [:test]
 
-puppetversion = ENV['PUPPET_VERSION'] || '~> 6.0'
+puppetversion = ENV['PUPPET_VERSION'] || '>= 6.0'
 gem 'puppet', puppetversion, :require => false, :groups => [:test]
 
 # vim: syntax=ruby

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # puppet-hyperglass
 
-[![Build Status](https://travis-ci.com/voxpupuli/puppet-hyperglass.svg?branch=master)](https://travis-ci.com/voxpupuli/puppet-hyperglass)
+[![CI](https://github.com/voxpupuli/puppet-hyperglass/actions/workflows/ci.yml/badge.svg)](https://github.com/voxpupuli/puppet-hyperglass/actions/workflows/ci.yml)
 [![Puppet Forge](https://img.shields.io/puppetforge/v/puppet/hyperglass.svg)](https://forge.puppetlabs.com/puppet/hyperglass)
 [![Puppet Forge - downloads](https://img.shields.io/puppetforge/dt/puppet/hyperglass.svg)](https://forge.puppetlabs.com/puppet/hyperglass)
 [![Puppet Forge - endorsement](https://img.shields.io/puppetforge/e/puppet/hyperglass.svg)](https://forge.puppetlabs.com/puppet/hyperglass)

--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.4.0 < 7.0.0"
+      "version_requirement": ">= 6.4.0 < 8.0.0"
     },
     {
       "name": "puppet/python",

--- a/metadata.json
+++ b/metadata.json
@@ -63,7 +63,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.8 < 7.0.0"
+      "version_requirement": ">= 6.1.0 < 8.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -25,7 +25,7 @@
     },
     {
       "name": "camptocamp/systemd",
-      "version_requirement": ">= 2.10.0 < 3.0.0"
+      "version_requirement": ">= 2.10.0 < 4.0.0"
     },
     {
       "name": "puppet/nodejs",

--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,7 @@
     },
     {
       "name": "puppet/redis",
-      "version_requirement": ">= 6.1.0 < 7.0.0"
+      "version_requirement": ">= 6.1.0 < 8.0.0"
     },
     {
       "name": "camptocamp/systemd",

--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,7 @@
   "dependencies": [
     {
       "name": "puppet/nginx",
-      "version_requirement": ">= 2.0.0 < 3.0.0"
+      "version_requirement": ">= 2.0.0 < 4.0.0"
     },
     {
       "name": "puppet/redis",

--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,7 @@
     },
     {
       "name": "puppet/nodejs",
-      "version_requirement": ">= 8.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/metadata.json
+++ b/metadata.json
@@ -37,7 +37,7 @@
     },
     {
       "name": "puppet/python",
-      "version_requirement": ">= 4.1.1 < 5.0.0"
+      "version_requirement": ">= 4.1.1 < 7.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -29,7 +29,7 @@ describe 'hyperglass::server class' do
     # This sleeps because hyperglass can take a long time to start. The service
     # check above returns successfully as the service is running though it has
     # not even bound to a port.
-    describe command('sleep 75; curl http://localhost:8001') do
+    describe command('sleep 150; curl http://localhost:8001') do
       its(:stdout) { is_expected.to match %r{hyperglass} }
     end
   end

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -21,6 +21,11 @@ describe 'hyperglass::server class' do
       it { is_expected.to be_enabled }
     end
 
+    describe service('nginx') do
+      it { is_expected.to be_running }
+      it { is_expected.to be_enabled }
+    end
+
     # This sleeps because hyperglass can take a long time to start. The service
     # check above returns successfully as the service is running though it has
     # not even bound to a port.


### PR DESCRIPTION
this PR also contains:
* https://github.com/voxpupuli/puppet-hyperglass/pull/18
* https://github.com/voxpupuli/puppet-hyperglass/pull/19
* https://github.com/voxpupuli/puppet-hyperglass/pull/20
* https://github.com/voxpupuli/puppet-hyperglass/pull/21
* https://github.com/voxpupuli/puppet-hyperglass/pull/22
* https://github.com/voxpupuli/puppet-hyperglass/pull/23
* https://github.com/voxpupuli/puppet-hyperglass/pull/24