### PR TITLE
puppet/nginx Allow 7.x, puppet/redis Allow 11.x, puppet/systemd Allow 8.x, puppet/nodejs Allow 11.x, puppetlabs/stdlib Allow 9.x, puppet/python Allow 8.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -17,27 +17,27 @@
   "dependencies": [
     {
       "name": "puppet/nginx",
-      "version_requirement": ">= 2.0.0 < 4.0.0"
+      "version_requirement": ">= 2.0.0 < 8.0.0"
     },
     {
       "name": "puppet/redis",
-      "version_requirement": ">= 6.1.0 < 9.0.0"
+      "version_requirement": ">= 6.1.0 < 12.0.0"
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 2.10.0 < 5.0.0"
+      "version_requirement": ">= 2.10.0 < 9.0.0"
     },
     {
       "name": "puppet/nodejs",
-      "version_requirement": ">= 8.0.0 < 10.0.0"
+      "version_requirement": ">= 8.0.0 < 12.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.4.0 < 9.0.0"
+      "version_requirement": ">= 6.4.0 < 10.0.0"
     },
     {
       "name": "puppet/python",
-      "version_requirement": ">= 4.1.1 < 7.0.0"
+      "version_requirement": ">= 4.1.1 < 9.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
    Ref: https://github.com/voxpupuli/community-triage/issues/44
