### PR TITLE
Update hyperglass website address

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Hyperglass Setup
 
-[Hyperglass](https://hyperglass.io/) is shipped as a
+[Hyperglass](https://hyperglass.dev/) is shipped as a
 [python package](https://pypi.org/project/hyperglass/). This Puppet module
 can install all the required services:
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -82,7 +82,7 @@ Default value:
 installs the hyperglass looking glass
 
 * **See also**
-  * https://hyperglass.io/
+  * https://hyperglass.dev/
 
 #### Parameters
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -7,7 +7,7 @@
 # @param commands specific commands that can be used by the devices
 # @param data generic hyperglass configuration hash.
 #
-# @see https://hyperglass.io/
+# @see https://hyperglass.dev/
 #
 # @author Tim Meusel <tim@bastelfreak.de>
 class hyperglass::server (


### PR DESCRIPTION
It's https://hyperglass.dev/ now. hyperglass.io redirects to some spam
site.
